### PR TITLE
Correct misspelling of architectures field name

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -6,4 +6,4 @@ sentence=Arduino library for easy usage of multiple sensor on ROHM Sensor Evalua
 paragraph=Alternative to the ROHM-provided source code
 category=Sensors
 url=https://github.com/jgromes/RohmMultiSensor
-architecture=*
+architectures=*


### PR DESCRIPTION
The correct spelling of the field name is architectures, not architecture.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format